### PR TITLE
Calc offsets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
     "makefile.launchConfigurations": [
         {
-            "cwd": "/home/epics-dev/work/epics/modules/omroneip/omroneipApp/src/O.linux-x86_64",
+            "cwd": "/home/epics-dev/work/epics/modules/omroneip/iocBoot/iocTest",
             "binaryPath": "/home/epics-dev/work/epics/modules/omroneip/omroneipApp/src/O.linux-x86_64/omroneipApp",
-            "binaryArgs": []
+            "binaryArgs": ["/home/epics-dev/work/epics/modules/omroneip/iocBoot/iocTest/st.cmd"]
         }
     ]
 }

--- a/include/drvOmroneip.h
+++ b/include/drvOmroneip.h
@@ -78,20 +78,26 @@ public:
   ~drvOmronEIP();
   bool omronExiting_;
 
+  /* All reading of data is initiated from this function which runs at a predefined frequency */
   void readPoller();
   /* Takes a csv style file, where each line contains a structure name followed by a list of datatypes within the struct
      Stores the user input struct as a map containing Struct:field_list pairs. It then calls createStructMap and passes this map */   
   asynStatus loadStructFile(const char * portName, const char * filePath);
-  /* Loops through each structure within the map and calls findOffsetsRecursive which creates the final structure offset map */
+  /* Loops through each structure within the map and calls findOffsets which creates the final structure offset map */
   asynStatus createStructMap(std::unordered_map<std::string, std::vector<std::string>> rawMap);
-  std::vector<std::string> expandStructs(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string structName);
+  /* Recursively extract datatypes from an embedded array, this array may contain embedded structs in which case expandStructsRecursive is called */
+  std::vector<std::string> expandArrayRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string arrayDesc);
+  /* Recursively extract datatypes from embedded structures and list them in the correct order */
+  std::vector<std::string> expandStructsRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string structName);
   /* A recursive function which is passed a row from the raw map and calculates the offset of each datatype in the row. If the datatype
      is the name of another structure, then the size of this structure must first be calculated by calling this function with the row for
      this structure. This process is repeated untill the offset for the lowest common structure is found which is returned by this function.
      The function then works its way back up. structMap is updated with the calculated offsets. */
-  size_t findOffsetsRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::unordered_map<std::string, std::vector<std::string>> const& expandedMap, std::string structName, std::unordered_map<std::string, std::vector<int>>& structMap, std::string parentNextDtype);
-  /* A recursive function which looks for the next standard dtype within embedded structures */
-  std::string findNextDtype(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string structName);
+  size_t findOffsets(std::unordered_map<std::string, std::vector<std::string>> const& expandedMap, std::string structName, std::unordered_map<std::string, std::vector<int>>& structMap);
+  /* Finds the datatype which an array type is defined with*/
+  std::string findArrayDtype(std::unordered_map<std::string, std::vector<std::string>> const& expandedMap, std::string arrayDesc);
+  /* Returns the largest standard datatype within a structure, this includes embedded structures and arrays and is used for calculating padding*/
+  size_t getBiggestDtype(std::unordered_map<std::string, std::vector<std::string>> const&, std::string structName);
   /* Creates a new instance of the omronEIPPoller class and starts a new thread named after this new poller which reads data linked to the poller name.*/
   asynStatus createPoller(const char * portName, const char * pollerName, double updateRate);
   /* Reimplemented from asynDriver. This is called when each record is loaded into epics. It processes the drvInfo from the record and attempts
@@ -123,7 +129,8 @@ private:
   std::string tagConnectionString_; // Stores the basic PLC connection information common to all read/write requests
   std::unordered_map<std::string, std::vector<int>> structMap_; // They key is the name of the struct, the vector is a list of byte offsets within the structure
   std::unordered_map<std::string, omronEIPPoller*> pollerList_ = {}; // Stores the name of each registered poller
-  std::unordered_map<int, omronDrvUser_t*> tagMap_; /* Maps the index of each registered asynParameter to essential communications data for the parameter */
+  std::unordered_map<int, omronDrvUser_t*> tagMap_;
+  /* Maps the index of each registered asynParameter to essential communications data for the parameter */
 };
 
 /* Class which stores information about each poller */

--- a/include/drvOmroneip.h
+++ b/include/drvOmroneip.h
@@ -82,6 +82,9 @@ public:
   asynStatus loadStructFile(const char * portName, const char * filePath);
   /* Loops through each structure within the map and calls findOffsets which creates the final structure offset map */
   asynStatus createStructMap(std::unordered_map<std::string, std::vector<std::string>> rawMap);
+  /* Takes the elements of a user defined structure requested by the user in the drvInfo string and finds their offsets
+     from the structMap_ */
+  size_t findRequestedOffset(std::vector<size_t> indices, std::string structMap);
   /* Recursively extract datatypes from an embedded array, this array may contain embedded structs in which case expandStructsRecursive is called */
   std::vector<std::string> expandArrayRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string arrayDesc);
   /* Recursively extract datatypes from embedded structures and list them in the correct order */
@@ -128,7 +131,12 @@ private:
   bool startPollers_;
   bool initialized_; // Tracks if the driver successfully initialized
   std::string tagConnectionString_; // Stores the basic PLC connection information common to all read/write requests
-  std::unordered_map<std::string, std::vector<int>> structMap_; // They key is the name of the struct, the vector is a list of byte offsets within the structure
+  // The key is the name of the struct, the vector is a list of byte offsets within the structure
+  std::unordered_map<std::string, std::vector<int>> structMap_;
+  /* The key is the name of the struct, the vector contains strings representing the dtypes and embbed structs/arrays. 
+  Used to match user requests to offsets in the structMap */
+  std::unordered_map<std::string, std::vector<std::string>> structDtypeMap_;
+  std::unordered_map<std::string, std::vector<std::string>> structRawMap_;
   std::unordered_map<std::string, omronEIPPoller*> pollerList_ = {}; // Stores the name of each registered poller
   std::unordered_map<int, omronDrvUser_t*> tagMap_;
   /* Maps the index of each registered asynParameter to essential communications data for the parameter */

--- a/include/drvOmroneip.h
+++ b/include/drvOmroneip.h
@@ -50,9 +50,6 @@ typedef enum {
   dataTypeUInt,
   dataTypeUDInt,
   dataTypeULInt,
-  dataTypeUInt_BCD,
-  dataTypeUDInt_BCD,
-  dataTypeULInt_BCD,
   dataTypeReal,
   dataTypeLReal,
   dataTypeString,
@@ -89,6 +86,10 @@ public:
   std::vector<std::string> expandArrayRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string arrayDesc);
   /* Recursively extract datatypes from embedded structures and list them in the correct order */
   std::vector<std::string> expandStructsRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string structName);
+  /* Calculate the alignment rules of an embedded structure or array, if nextItem is a structure then lookup the largest item in the structure.
+     If nextItem is an array, then follow the alignment rule of the item after nextItem, it this item is a struct, then look up the largest
+     item in this struct */
+  size_t getEmbeddedAlignment(std::unordered_map<std::string, std::vector<std::string>> const& expandedMap, std::string structName, std::string nextItem, size_t i);
   /* A recursive function which is passed a row from the raw map and calculates the offset of each datatype in the row. If the datatype
      is the name of another structure, then the size of this structure must first be calculated by calling this function with the row for
      this structure. This process is repeated untill the offset for the lowest common structure is found which is returned by this function.

--- a/iocBoot/iocTest/st.cmd
+++ b/iocBoot/iocTest/st.cmd
@@ -10,7 +10,7 @@ omroneipApp_registerRecordDeviceDriver(pdbbase)
 drvOmronEIPConfigure("omronDriver", "10.2.2.57", "18,10.2.2.57","omron-njnx", "2")
 
 #asynSetTraceFile omronDriver 0 asynTrace.out
-#asynSetTraceMask omronDriver 0 0x00FF
+asynSetTraceMask omronDriver 0 0x00FF #everything
 #asynSetTraceMask omronDriver 0 0x0037
 #asynSetTraceMask omronDriver 0 0x0021
 
@@ -26,12 +26,12 @@ drvOmronEIPStructDefine("omronDriver", "iocBoot/iocTest/structDefs.csv")
 #dbLoadRecords("db/testHeatingZones.db", "P=${P}, PORT=omronDriver, POLLER=mediumPoller")
 #dbLoadTemplate("iocBoot/iocTest/testISIS.substitutions")
 #dbLoadRecords("db/testWriteDataTypes.db", "P=${P}, I=1, PORT=omronDriver")
-dbLoadRecords("db/testReadDataTypes.db", "P=${P}, I=1, PORT=omronDriver, POLLER=fastPoller")
+#dbLoadRecords("db/testReadDataTypes.db", "P=${P}, I=1, PORT=omronDriver, POLLER=fastPoller")
 
 #dbLoadRecords("db/testInefficientRead.db", "P=${P}, I=1, R=1:, PORT=omronDriver, POLLER=fastPoller")
 #dbLoadRecords("db/testEfficientRead.db", "P=${P}, I=2, R=2:, PORT=omronDriver, POLLER=fastPoller")
 
-#dbLoadRecords("db/test.db", "P=${P}, PORT=omronDriver, POLLER=mediumPoller")
+dbLoadRecords("db/test.db", "P=${P}, PORT=omronDriver, POLLER=mediumPoller")
 #dbLoadRecords("db/testReadNoPacking.db", "P=${P}, PORT=omronDriver, POLLER=slowPoller") #doesnt work properly atm
 #dbLoadRecords("db/testReadPacking.db", "P=${P}, PORT=omronDriver, POLLER=slowPoller") #doesnt work properly atm
 #dbLoadRecords("db/testWeirdINP.db", "P=${P}, PORT=omronDriver, POLLER=mediumPoller") #doesnt work properly atm

--- a/omroneipApp/Db/test.db
+++ b/omroneipApp/Db/test.db
@@ -83,13 +83,35 @@
 #    field(NELM, "1996")
 #}
 
-record(waveform, "$(P)readZones") {
+record(ai, "$(P)readZoneReal") {
     field(SCAN, "I/O Intr")
-    field(FTVL, "UCHAR")
-    field(DTYP, "asynInt8ArrayIn")
-    field(INP, "@asyn($(PORT), 0, 1)@$(POLLER) Zones[1] UDT none none none")
-    field(NELM, "1996")
+    field(DTYP, "asynFloat64")
+    field(INP, "@asyn($(PORT), 0, 1)@$(POLLER) Zones[1] REAL none UDT800_Zone[43] none")
 }
+
+record(ai, "$(P)readZoneReal2") {
+    field(SCAN, "I/O Intr")
+    field(DTYP, "asynFloat64")
+    field(INP, "@asyn($(PORT), 0, 1)@$(POLLER) Zones[1] REAL none UDT800_Zone[0][42][9] none")
+}
+
+record(ai, "$(P)readZoneReal3") {
+    field(SCAN, "I/O Intr")
+    field(DTYP, "asynFloat64")
+    field(INP, "@asyn($(PORT), 0, 1)@$(POLLER) Zones[1] REAL none UDT800_Zone[1] none")
+}
+
+record(ai, "$(P)readZoneReal4") {
+    field(SCAN, "I/O Intr")
+    field(DTYP, "asynFloat64")
+    field(INP, "@asyn($(PORT), 0, 1)@$(POLLER) Zones[1] REAL none UDT800_Zone[0][10] none")
+}
+
+#record(ai, "$(P)readZoneReal5") {
+#    field(SCAN, "I/O Intr")
+#    field(DTYP, "asynFloat64")
+#    field(INP, "@asyn($(PORT), 0, 1)@$(POLLER) Zones[1] REAL none UDT800_Zone[0][1] none")
+#}
 
 #record(waveform, "$(P)writeUDT") {
 #    field(FTVL, "UCHAR")

--- a/omroneipApp/Db/test.db
+++ b/omroneipApp/Db/test.db
@@ -83,11 +83,11 @@
 #    field(NELM, "1996")
 #}
 
-record(waveform, "$(P)readISIS2") {
+record(waveform, "$(P)readZones") {
     field(SCAN, "I/O Intr")
     field(FTVL, "UCHAR")
     field(DTYP, "asynInt8ArrayIn")
-    field(INP, "@asyn($(PORT), 0, 1)@$(POLLER) ISISTestMultiple[8] UDT 10 none &elem_size=1428&allow_packing=1")
+    field(INP, "@asyn($(PORT), 0, 1)@$(POLLER) Zones[1] UDT none none none")
     field(NELM, "1996")
 }
 

--- a/omroneipApp/src/drvOmroneip.h
+++ b/omroneipApp/src/drvOmroneip.h
@@ -78,20 +78,26 @@ public:
   ~drvOmronEIP();
   bool omronExiting_;
 
+  /* All reading of data is initiated from this function which runs at a predefined frequency */
   void readPoller();
   /* Takes a csv style file, where each line contains a structure name followed by a list of datatypes within the struct
      Stores the user input struct as a map containing Struct:field_list pairs. It then calls createStructMap and passes this map */   
   asynStatus loadStructFile(const char * portName, const char * filePath);
-  /* Loops through each structure within the map and calls findOffsetsRecursive which creates the final structure offset map */
+  /* Loops through each structure within the map and calls findOffsets which creates the final structure offset map */
   asynStatus createStructMap(std::unordered_map<std::string, std::vector<std::string>> rawMap);
-  std::vector<std::string> expandStructs(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string structName);
+  /* Recursively extract datatypes from an embedded array, this array may contain embedded structs in which case expandStructsRecursive is called */
+  std::vector<std::string> expandArrayRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string arrayDesc);
+  /* Recursively extract datatypes from embedded structures and list them in the correct order */
+  std::vector<std::string> expandStructsRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string structName);
   /* A recursive function which is passed a row from the raw map and calculates the offset of each datatype in the row. If the datatype
      is the name of another structure, then the size of this structure must first be calculated by calling this function with the row for
      this structure. This process is repeated untill the offset for the lowest common structure is found which is returned by this function.
      The function then works its way back up. structMap is updated with the calculated offsets. */
-  size_t findOffsetsRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::unordered_map<std::string, std::vector<std::string>> const& expandedMap, std::string structName, std::unordered_map<std::string, std::vector<int>>& structMap, std::string parentNextDtype);
-  /* A recursive function which looks for the next standard dtype within embedded structures */
-  std::string findNextDtype(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string structName);
+  size_t findOffsets(std::unordered_map<std::string, std::vector<std::string>> const& expandedMap, std::string structName, std::unordered_map<std::string, std::vector<int>>& structMap);
+  /* Finds the datatype which an array type is defined with*/
+  std::string findArrayDtype(std::unordered_map<std::string, std::vector<std::string>> const& expandedMap, std::string arrayDesc);
+  /* Returns the largest standard datatype within a structure, this includes embedded structures and arrays and is used for calculating padding*/
+  size_t getBiggestDtype(std::unordered_map<std::string, std::vector<std::string>> const&, std::string structName);
   /* Creates a new instance of the omronEIPPoller class and starts a new thread named after this new poller which reads data linked to the poller name.*/
   asynStatus createPoller(const char * portName, const char * pollerName, double updateRate);
   /* Reimplemented from asynDriver. This is called when each record is loaded into epics. It processes the drvInfo from the record and attempts
@@ -123,7 +129,8 @@ private:
   std::string tagConnectionString_; // Stores the basic PLC connection information common to all read/write requests
   std::unordered_map<std::string, std::vector<int>> structMap_; // They key is the name of the struct, the vector is a list of byte offsets within the structure
   std::unordered_map<std::string, omronEIPPoller*> pollerList_ = {}; // Stores the name of each registered poller
-  std::unordered_map<int, omronDrvUser_t*> tagMap_; /* Maps the index of each registered asynParameter to essential communications data for the parameter */
+  std::unordered_map<int, omronDrvUser_t*> tagMap_;
+  /* Maps the index of each registered asynParameter to essential communications data for the parameter */
 };
 
 /* Class which stores information about each poller */

--- a/omroneipApp/src/drvOmroneip.h
+++ b/omroneipApp/src/drvOmroneip.h
@@ -82,6 +82,9 @@ public:
   asynStatus loadStructFile(const char * portName, const char * filePath);
   /* Loops through each structure within the map and calls findOffsets which creates the final structure offset map */
   asynStatus createStructMap(std::unordered_map<std::string, std::vector<std::string>> rawMap);
+  /* Takes the elements of a user defined structure requested by the user in the drvInfo string and finds their offsets
+     from the structMap_ */
+  size_t findRequestedOffset(std::vector<size_t> indices, std::string structMap);
   /* Recursively extract datatypes from an embedded array, this array may contain embedded structs in which case expandStructsRecursive is called */
   std::vector<std::string> expandArrayRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string arrayDesc);
   /* Recursively extract datatypes from embedded structures and list them in the correct order */
@@ -128,7 +131,12 @@ private:
   bool startPollers_;
   bool initialized_; // Tracks if the driver successfully initialized
   std::string tagConnectionString_; // Stores the basic PLC connection information common to all read/write requests
-  std::unordered_map<std::string, std::vector<int>> structMap_; // They key is the name of the struct, the vector is a list of byte offsets within the structure
+  // The key is the name of the struct, the vector is a list of byte offsets within the structure
+  std::unordered_map<std::string, std::vector<int>> structMap_;
+  /* The key is the name of the struct, the vector contains strings representing the dtypes and embbed structs/arrays. 
+  Used to match user requests to offsets in the structMap */
+  std::unordered_map<std::string, std::vector<std::string>> structDtypeMap_;
+  std::unordered_map<std::string, std::vector<std::string>> structRawMap_;
   std::unordered_map<std::string, omronEIPPoller*> pollerList_ = {}; // Stores the name of each registered poller
   std::unordered_map<int, omronDrvUser_t*> tagMap_;
   /* Maps the index of each registered asynParameter to essential communications data for the parameter */

--- a/omroneipApp/src/drvOmroneip.h
+++ b/omroneipApp/src/drvOmroneip.h
@@ -50,9 +50,6 @@ typedef enum {
   dataTypeUInt,
   dataTypeUDInt,
   dataTypeULInt,
-  dataTypeUInt_BCD,
-  dataTypeUDInt_BCD,
-  dataTypeULInt_BCD,
   dataTypeReal,
   dataTypeLReal,
   dataTypeString,
@@ -89,6 +86,10 @@ public:
   std::vector<std::string> expandArrayRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string arrayDesc);
   /* Recursively extract datatypes from embedded structures and list them in the correct order */
   std::vector<std::string> expandStructsRecursive(std::unordered_map<std::string, std::vector<std::string>> const& rawMap, std::string structName);
+  /* Calculate the alignment rules of an embedded structure or array, if nextItem is a structure then lookup the largest item in the structure.
+     If nextItem is an array, then follow the alignment rule of the item after nextItem, it this item is a struct, then look up the largest
+     item in this struct */
+  size_t getEmbeddedAlignment(std::unordered_map<std::string, std::vector<std::string>> const& expandedMap, std::string structName, std::string nextItem, size_t i);
   /* A recursive function which is passed a row from the raw map and calculates the offset of each datatype in the row. If the datatype
      is the name of another structure, then the size of this structure must first be calculated by calling this function with the row for
      this structure. This process is repeated untill the offset for the lowest common structure is found which is returned by this function.


### PR DESCRIPTION
A have created a new implementation of my algorithms which calculate the offsets of variables within structures. This works for all standard datatypes, embedded structures and (not tested yet) embedded arrays. It also correctly calculates padding and returns a map of each defined structure to the raw datatypes within.

I have also created an algorithm which allows users to get the offsets of all raw dtypes in this map and the offsets of embedded structures/arrays. A user can use the syntax: structureName[a][b][c], where c is a structure embedded in structure b which is inside the main structure.

I will create some unit tests to fully test these algorithms at some point, as they are rather complex due to the flexible nature of structures. There is currently a moderate chance that there will be a bug in some unexpected setup.